### PR TITLE
Small fixes

### DIFF
--- a/dist/LambdaSequence.d.ts
+++ b/dist/LambdaSequence.d.ts
@@ -95,6 +95,11 @@ export declare class LambdaSequence {
     next<T extends IDictionary>(
     /** the _current_ function's response */
     currentFnResponse?: Partial<T>): ILambdaSequenceNextTuple<T>;
+    private getInvocationParameters;
+    /**
+     * Invokes the first function in a new sequence.
+     */
+    start<T extends IDictionary = IDictionary>(): Promise<import("aws-sdk/clients/lambda").InvocationResponse>;
     /**
      * Ensures that you can't call yourself in a sequence unless this has been
      * enabled explicitly.

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,6 +1,6 @@
 import { HttpStatusCodes, isLambdaProxyRequest, getBodyFromPossibleLambdaProxyRequest } from 'common-types';
 import { compress as compress$1, decompress as decompress$1 } from 'lzutf8';
-import { logger, invoke as invoke$1, getCorrelationId } from 'aws-log';
+import { logger, getCorrelationId, invoke as invoke$1 } from 'aws-log';
 import get from 'lodash.get';
 import flatten from 'lodash.flatten';
 import set from 'lodash.set';
@@ -638,14 +638,6 @@ function maskLoggingForSecrets(modules, log) {
   }
 }
 
-/**
- * Wraps the functionality provided by the `aws-log`'s **invoke()** function
- * that ensures that improper self-calling is prohibited unless expressly enabled
- *
- * @param fnArn the Function's ARN
- * @param request The request object to pass to the next function
- */
-
 function _async$1(f) {
   return function () {
     for (var args = [], i = 0; i < arguments.length; i++) {
@@ -660,35 +652,12 @@ function _async$1(f) {
   };
 }
 
-var invoke = _async$1(function (fnArn, request) {
-  return invoke$1(fnArn, request);
-});
-
-function _async$2(f) {
-  return function () {
-    for (var args = [], i = 0; i < arguments.length; i++) {
-      args[i] = arguments[i];
-    }
-
-    try {
-      return Promise.resolve(f.apply(this, args));
-    } catch (e) {
-      return Promise.reject(e);
-    }
-  };
-}
-
-var invokeNewSequence = _async$2(function () {
-  var results = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+var invokeNewSequence = _async$1(function () {
 
   if (!newSequence) {
     return;
   }
-
-  results = results || {};
-  return invoke.apply(void 0, _toConsumableArray(newSequence.next(_typeof(results) === "object" ? results : {
-    data: results
-  })));
+  return newSequence.start();
 });
 var newSequence;
 /**
@@ -888,7 +857,7 @@ function _invoke(body, then) {
   return then(result);
 }
 
-function _async$3(f) {
+function _async$2(f) {
   return function () {
     for (var args = [], i = 0; i < arguments.length; i++) {
       args[i] = arguments[i];
@@ -902,7 +871,7 @@ function _async$3(f) {
   };
 }
 
-var database = _async$3(function (config) {
+var database = _async$2(function (config) {
   var log = logger().reloadContext();
   return _invoke(function () {
     if (!_database) {
@@ -1050,6 +1019,32 @@ additionalHeaders) {
   };
 }
 
+/**
+ * Wraps the functionality provided by the `aws-log`'s **invoke()** function
+ * that ensures that improper self-calling is prohibited unless expressly enabled
+ *
+ * @param fnArn the Function's ARN
+ * @param request The request object to pass to the next function
+ */
+
+function _async$3(f) {
+  return function () {
+    for (var args = [], i = 0; i < arguments.length; i++) {
+      args[i] = arguments[i];
+    }
+
+    try {
+      return Promise.resolve(f.apply(this, args));
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  };
+}
+
+var invoke = _async$3(function (fnArn, request) {
+  return invoke$1(fnArn, request);
+});
+
 var LambdaSequence =
 /*#__PURE__*/
 function () {
@@ -1060,6 +1055,11 @@ function () {
      * The steps defined in the sequence
      */
     this._steps = [];
+    /**
+     * The responses from completed functions in a sequence
+     */
+
+    this._responses = {};
   }
   /**
    * **add** (static initializer)
@@ -1126,16 +1126,29 @@ function () {
     value: function next() {
       var currentFnResponse = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       this.finishStep(currentFnResponse);
+      return this.getInvocationParameters();
+    }
+  }, {
+    key: "getInvocationParameters",
+    value: function getInvocationParameters() {
       /**
        * Because `activeFn` has been moved forward to the "next function"
        * using the `activeFn` reference is correct
        **/
-
       var body = this.resolveRequestProperties(this.activeFn);
       var arn = this.activeFn.arn;
       this.validateCallDepth();
       var request = buildOrchestratedRequest(body, this);
       return [arn, request];
+    }
+    /**
+     * Invokes the first function in a new sequence.
+     */
+
+  }, {
+    key: "start",
+    value: function start() {
+      return invoke.apply(void 0, _toConsumableArray(this.getInvocationParameters()));
     }
     /**
      * Ensures that you can't call yourself in a sequence unless this has been
@@ -1144,7 +1157,8 @@ function () {
 
   }, {
     key: "validateCallDepth",
-    value: function validateCallDepth() {}
+    value: function validateCallDepth() {} // TODO: implement
+
     /**
      * **from**
      *
@@ -1411,6 +1425,10 @@ function () {
   }, {
     key: "activeFn",
     get: function get() {
+      if (!this._steps.length) {
+        return;
+      }
+
       var log = logger().reloadContext();
       var active = this._steps ? this._steps.filter(function (s) {
         return s.status === "active";
@@ -1426,6 +1444,10 @@ function () {
         var step = this._steps.find(function (i) {
           return i.status === "assigned";
         });
+
+        if (!step) {
+          throw new Error("Problem resolving activeFn: no step with status \"assigned\" found. \n\n ".concat(JSON.stringify(this._steps)));
+        }
 
         step.status = "active";
         return this.activeFn;

--- a/dist/index.js
+++ b/dist/index.js
@@ -663,14 +663,6 @@ function maskLoggingForSecrets(modules, log) {
   }
 }
 
-/**
- * Wraps the functionality provided by the `aws-log`'s **invoke()** function
- * that ensures that improper self-calling is prohibited unless expressly enabled
- *
- * @param fnArn the Function's ARN
- * @param request The request object to pass to the next function
- */
-
 function _async$1(f) {
   return function () {
     for (var args = [], i = 0; i < arguments.length; i++) {
@@ -685,35 +677,12 @@ function _async$1(f) {
   };
 }
 
-var invoke = _async$1(function (fnArn, request) {
-  return awsLog.invoke(fnArn, request);
-});
-
-function _async$2(f) {
-  return function () {
-    for (var args = [], i = 0; i < arguments.length; i++) {
-      args[i] = arguments[i];
-    }
-
-    try {
-      return Promise.resolve(f.apply(this, args));
-    } catch (e) {
-      return Promise.reject(e);
-    }
-  };
-}
-
-var invokeNewSequence = _async$2(function () {
-  var results = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+var invokeNewSequence = _async$1(function () {
 
   if (!newSequence) {
     return;
   }
-
-  results = results || {};
-  return invoke.apply(void 0, _toConsumableArray(newSequence.next(_typeof(results) === "object" ? results : {
-    data: results
-  })));
+  return newSequence.start();
 });
 var newSequence;
 /**
@@ -913,7 +882,7 @@ function _invoke(body, then) {
   return then(result);
 }
 
-function _async$3(f) {
+function _async$2(f) {
   return function () {
     for (var args = [], i = 0; i < arguments.length; i++) {
       args[i] = arguments[i];
@@ -927,7 +896,7 @@ function _async$3(f) {
   };
 }
 
-var database = _async$3(function (config) {
+var database = _async$2(function (config) {
   var log = awsLog.logger().reloadContext();
   return _invoke(function () {
     if (!_database) {
@@ -1075,6 +1044,32 @@ additionalHeaders) {
   };
 }
 
+/**
+ * Wraps the functionality provided by the `aws-log`'s **invoke()** function
+ * that ensures that improper self-calling is prohibited unless expressly enabled
+ *
+ * @param fnArn the Function's ARN
+ * @param request The request object to pass to the next function
+ */
+
+function _async$3(f) {
+  return function () {
+    for (var args = [], i = 0; i < arguments.length; i++) {
+      args[i] = arguments[i];
+    }
+
+    try {
+      return Promise.resolve(f.apply(this, args));
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  };
+}
+
+var invoke = _async$3(function (fnArn, request) {
+  return awsLog.invoke(fnArn, request);
+});
+
 var LambdaSequence =
 /*#__PURE__*/
 function () {
@@ -1085,6 +1080,11 @@ function () {
      * The steps defined in the sequence
      */
     this._steps = [];
+    /**
+     * The responses from completed functions in a sequence
+     */
+
+    this._responses = {};
   }
   /**
    * **add** (static initializer)
@@ -1151,16 +1151,29 @@ function () {
     value: function next() {
       var currentFnResponse = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       this.finishStep(currentFnResponse);
+      return this.getInvocationParameters();
+    }
+  }, {
+    key: "getInvocationParameters",
+    value: function getInvocationParameters() {
       /**
        * Because `activeFn` has been moved forward to the "next function"
        * using the `activeFn` reference is correct
        **/
-
       var body = this.resolveRequestProperties(this.activeFn);
       var arn = this.activeFn.arn;
       this.validateCallDepth();
       var request = buildOrchestratedRequest(body, this);
       return [arn, request];
+    }
+    /**
+     * Invokes the first function in a new sequence.
+     */
+
+  }, {
+    key: "start",
+    value: function start() {
+      return invoke.apply(void 0, _toConsumableArray(this.getInvocationParameters()));
     }
     /**
      * Ensures that you can't call yourself in a sequence unless this has been
@@ -1169,7 +1182,8 @@ function () {
 
   }, {
     key: "validateCallDepth",
-    value: function validateCallDepth() {}
+    value: function validateCallDepth() {} // TODO: implement
+
     /**
      * **from**
      *
@@ -1436,6 +1450,10 @@ function () {
   }, {
     key: "activeFn",
     get: function get() {
+      if (!this._steps.length) {
+        return;
+      }
+
       var log = awsLog.logger().reloadContext();
       var active = this._steps ? this._steps.filter(function (s) {
         return s.status === "active";
@@ -1451,6 +1469,10 @@ function () {
         var step = this._steps.find(function (i) {
           return i.status === "assigned";
         });
+
+        if (!step) {
+          throw new Error("Problem resolving activeFn: no step with status \"assigned\" found. \n\n ".concat(JSON.stringify(this._steps)));
+        }
 
         step.status = "active";
         return this.activeFn;

--- a/src/wrapper-fn/sequences.ts
+++ b/src/wrapper-fn/sequences.ts
@@ -30,10 +30,6 @@ export async function invokeNewSequence(results: any = {}) {
     return;
   }
   results = results || {};
-  const response = await invoke(
-    ...newSequence.next(
-      typeof results === "object" ? results : { data: results }
-    )
-  );
+  const response = await newSequence.start();
   return response;
 }


### PR DESCRIPTION
Fixes include

- throw error when there are no steps with status `assigned` when resolving `activeFn`
- fix the call to next step in a sequence
- set default value of `_responses` to empty object (LambdaSequence class)